### PR TITLE
Adding feature: Track all selected indexes each time when user selects the tag.

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -357,6 +357,11 @@ open class TagListView: UIView {
         return tagViews.filter() { $0.isSelected == true }
     }
     
+    //track all selected indexes whenever user selects the tag each time.
+    open func selectedTagIndexes() -> [Int] {
+        return tagViews.enumerated().filter{ $1.isSelected == true }.map { $0.offset }
+    }
+    
     // MARK: - Events
     
     func tagPressed(_ sender: TagView!) {


### PR DESCRIPTION
In this PR:
- we can track all selected indexes each time user selects the tag. 
For example: In tagPressed delegate method, 
```tagView.isSelected = tagView.isSelected
print(tagListView.selectedTagIndexes())``` //prints :  0 , 2 (if 0 and 2 are selected)