### PR TITLE
Println is now print

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can implement `TagListViewDelegate` to receive tag pressed event:
 }
 
 func tagPressed(title: String, tagView: TagView, sender: TagListView) {
-    println("Tag pressed: \(title), \(sender)")
+    print("Tag pressed: \(title), \(sender)")
 }
 ```
 
@@ -51,7 +51,7 @@ You can also customize a particular tag, or set tap handler for it by manipulati
 let tagView = tagListView.addTag("blue")
 tagView.tagBackgroundColor = UIColor.blueColor()
 tagView.onTap = { tagView in
-    println("Don’t tap me!")
+    print("Don’t tap me!")
 }
 ```
 


### PR DESCRIPTION
`Println` has been renamed to  `print` in Swift 3.