### PR TITLE
Update TagListView to support max number of displayable rows

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -16,6 +16,13 @@ import UIKit
 @IBDesignable
 open class TagListView: UIView {
     
+    // Similar to UILabel `numberOfLines`, 0 means infinite
+    open var displayableRows = 0 {
+        didSet {
+            rearrangeViews()
+        }
+    }
+    
     @IBInspectable open dynamic var textColor: UIColor = UIColor.white {
         didSet {
             for tagView in tagViews {
@@ -233,6 +240,9 @@ open class TagListView: UIView {
             tagViewHeight = tagView.frame.height
             
             if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width > frame.width {
+                if displayableRows != 0 && currentRow + 1 > displayableRows {
+                    break
+                }
                 currentRow += 1
                 currentRowWidth = 0
                 currentRowTagCount = 0


### PR DESCRIPTION
Adding support for a max number of displayable rows. Default is 0, which like in UILabel means infinite.