### PR TITLE
make round/square tag view if tag contains only one symbol

### DIFF
--- a/TagListView/TagView.swift
+++ b/TagListView/TagView.swift
@@ -181,6 +181,9 @@ open class TagView: UIButton {
         var size = titleLabel?.text?.size(attributes: [NSFontAttributeName: textFont]) ?? CGSize.zero
         size.height = textFont.pointSize + paddingY * 2
         size.width += paddingX * 2
+        if size.width < size.height {
+            size.width = size.height
+        }
         if enableRemoveButton {
             size.width += removeButtonIconSize + paddingX
         }


### PR DESCRIPTION
if tag contains only one symbol and round corner is equal of half of heigh then tag view looks ugly - take a look attached screenshots

before changes:
![screen shot 2017-03-17 at 17 41 06](https://cloud.githubusercontent.com/assets/2028094/24053441/5d80db3c-0b39-11e7-98bb-9569b083d30e.png)

after changes - make it round:
![screen shot 2017-03-17 at 17 41 29](https://cloud.githubusercontent.com/assets/2028094/24053442/5d9be6a2-0b39-11e7-874d-d9e28c32d6d2.png)
