### PR TITLE
Option to disable the wrapping of tags to next row

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -180,6 +180,12 @@ open class TagListView: UIView {
         }
     }
     
+    @IBInspectable open dynamic var wrapTagsToNextRow: Bool = true {
+        didSet {
+            rearrangeViews()
+        }
+    }
+    
     open dynamic var textFont: UIFont = UIFont.systemFont(ofSize: 12) {
         didSet {
             for tagView in tagViews {
@@ -232,7 +238,8 @@ open class TagListView: UIView {
             tagView.frame.size = tagView.intrinsicContentSize
             tagViewHeight = tagView.frame.height
             
-            if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width > frame.width {
+            if currentRowTagCount == 0 ||
+                (currentRowWidth + tagView.frame.width > frame.width && wrapTagsToNextRow) {
                 currentRow += 1
                 currentRowWidth = 0
                 currentRowTagCount = 0

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -201,6 +201,7 @@ open class TagListView: UIView {
     private(set) var tagBackgroundViews: [UIView] = []
     private(set) var rowViews: [UIView] = []
     private(set) var tagViewHeight: CGFloat = 0
+    private(set) var totalTagViewsWidth: CGFloat = 0
     private(set) var rows = 0 {
         didSet {
             invalidateIntrinsicContentSize()
@@ -231,13 +232,14 @@ open class TagListView: UIView {
         rowViews.removeAll(keepingCapacity: true)
         
         var currentRow = 0
+        totalTagViewsWidth = 0
         var currentRowView: UIView!
         var currentRowTagCount = 0
         var currentRowWidth: CGFloat = 0
         for (index, tagView) in tagViews.enumerated() {
             tagView.frame.size = tagView.intrinsicContentSize
             tagViewHeight = tagView.frame.height
-            
+            totalTagViewsWidth += tagView.frame.width
             if currentRowTagCount == 0 ||
                 (currentRowWidth + tagView.frame.width > frame.width && wrapTagsToNextRow) {
                 currentRow += 1
@@ -287,7 +289,11 @@ open class TagListView: UIView {
         if rows > 0 {
             height -= marginY
         }
-        return CGSize(width: frame.width, height: height)
+        var width = frame.width
+        if !wrapTagsToNextRow {
+            width = (CGFloat(tagViews.count - 1) * marginX) + totalTagViewsWidth
+        }
+        return CGSize(width: width, height: height)
     }
     
     private func createNewTagView(_ title: String) -> TagView {


### PR DESCRIPTION
Currently, the tags list is wrapped to next row when the row width gets greater than the view width. So if we have to include the TagListView in a horizontal scrollview its not possible.

I have added a new property `wrapTagsToNextRow` which is `true` by default. 

```
    @IBInspectable open dynamic var wrapTagsToNextRow: Bool = true {
        didSet {
            rearrangeViews()
        }
    }
```
So the default behaviours of the  TagListView doesn't change. But if user wish to change wrapTagsToNextRow to `false`, then all the tags are listed in one row. And this would allow the user to add TagListView to a UIScrollView which can be scrolled horizontally.