### PR TITLE
Add init methods to TagListView to resolve IBDesignable issues

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -201,6 +201,16 @@ open class TagListView: UIView {
         }
     }
     
+    // MARK: - Init
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
     // MARK: - Interface Builder
     
     open override func prepareForInterfaceBuilder() {


### PR DESCRIPTION
Added initializers "required" for IBDesignables to the TagListView.

Fixes #71,  #123 