### PR TITLE
Resize sublayers

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -213,7 +213,6 @@ open class TagListView: UIView {
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        
         rearrangeViews()
     }
     
@@ -231,6 +230,11 @@ open class TagListView: UIView {
         for (index, tagView) in tagViews.enumerated() {
             tagView.frame.size = tagView.intrinsicContentSize
             tagViewHeight = tagView.frame.height
+            if let subs = tagView.layer.sublayers{
+                for sub in subs{
+                    sub.frame = tagView.layer.frame
+                }
+            }
             
             if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width > frame.width {
                 currentRow += 1

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -233,6 +233,7 @@ open class TagListView: UIView {
             })
             let originalFrame = tagView.layer.frame
             tagView.frame.size = tagView.intrinsicContentSize
+            NotificationCenter.default.post(name: .TagViewFrameWasUpdatedNotification, object: tagView)
             tagViewHeight = tagView.frame.height
             if let originalFrames = originalSublayerFrames, let sublayers = tagView.layer.sublayers{
                 for (index, sublayer) in sublayers.enumerated(){
@@ -416,10 +417,14 @@ open class TagListView: UIView {
         sender.onTap?(sender)
         delegate?.tagPressed?(sender.currentTitle ?? "", tagView: sender, sender: self)
     }
-    
+
     @objc func removeButtonPressed(_ closeButton: CloseButton!) {
         if let tagView = closeButton.tagView {
             delegate?.tagRemoveButtonPressed?(tagView.currentTitle ?? "", tagView: tagView, sender: self)
         }
     }
+}
+
+extension Notification.Name{
+    static let TagViewFrameWasUpdatedNotification = Notification.Name("TagViewFrameWasUpdatedNotification")
 }

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -228,14 +228,20 @@ open class TagListView: UIView {
         var currentRowTagCount = 0
         var currentRowWidth: CGFloat = 0
         for (index, tagView) in tagViews.enumerated() {
+            let originalSublayerFrames = tagView.layer.sublayers?.map({ (layer: CALayer) -> CGRect in
+                return layer.frame
+            })
+            let originalFrame = tagView.layer.frame
             tagView.frame.size = tagView.intrinsicContentSize
             tagViewHeight = tagView.frame.height
-            if let subs = tagView.layer.sublayers{
-                for sub in subs{
-                    sub.frame = tagView.layer.frame
+            if let originalFrames = originalSublayerFrames, let sublayers = tagView.layer.sublayers{
+                for (index, sublayer) in sublayers.enumerated(){
+                    if originalFrames[index] == originalFrame{
+                        sublayer.frame = tagView.layer.frame
+                    }
                 }
             }
-            
+
             if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width > frame.width {
                 currentRow += 1
                 currentRowWidth = 0

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -36,7 +36,7 @@ class ViewController: UIViewController, TagListViewDelegate {
         gradient.colors = [#colorLiteral(red: 0.9803921569, green: 0.9803921569, blue: 0, alpha: 1).cgColor, #colorLiteral(red: 0.9803921569, green: 0.8156862745, blue: 0, alpha: 1).cgColor]
         gradient.startPoint = .zero
         gradient.endPoint = CGPoint(x: 1, y: 1)
-        gradient.frame = tag.layer.frame
+        gradient.frame = CGRect(origin: CGPoint(x: 5, y: 5), size: tag.layer.frame.size)
         tag.layer.addSublayer(gradient)
 
         let tagView = tagListView.addTag("gray")

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -27,7 +27,18 @@ class ViewController: UIViewController, TagListViewDelegate {
         tagListView.addTag("On tap will be removed").onTap = { [weak self] tagView in
             self?.tagListView.removeTagView(tagView)
         }
-        
+
+        let tag = tagListView.addTag("Example")
+        tag.paddingX = 12
+        tag.paddingY = 14
+        tag.enableRemoveButton = true
+        let gradient = CAGradientLayer()
+        gradient.colors = [#colorLiteral(red: 0.9803921569, green: 0.9803921569, blue: 0, alpha: 1).cgColor, #colorLiteral(red: 0.9803921569, green: 0.8156862745, blue: 0, alpha: 1).cgColor]
+        gradient.startPoint = .zero
+        gradient.endPoint = CGPoint(x: 1, y: 1)
+        gradient.frame = tag.layer.frame
+        tag.layer.addSublayer(gradient)
+
         let tagView = tagListView.addTag("gray")
         tagView.tagBackgroundColor = UIColor.gray
         tagView.onTap = { tagView in

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -38,6 +38,7 @@ class ViewController: UIViewController, TagListViewDelegate {
         gradient.endPoint = CGPoint(x: 1, y: 1)
         gradient.frame = CGRect(origin: CGPoint(x: 5, y: 5), size: tag.layer.frame.size)
         tag.layer.addSublayer(gradient)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateTagFrame(from:)), name: .TagViewFrameWasUpdatedNotification, object: tag)
 
         let tagView = tagListView.addTag("gray")
         tagView.tagBackgroundColor = UIColor.gray
@@ -80,6 +81,15 @@ class ViewController: UIViewController, TagListViewDelegate {
     func tagRemoveButtonPressed(_ title: String, tagView: TagView, sender: TagListView) {
         print("Tag Remove pressed: \(title), \(sender)")
         sender.removeTagView(tagView)
+    }
+
+    @objc func updateTagFrame(from notification: Notification) -> Void{
+        guard let tag = notification.object as? TagView, let sublayers = tag.layer.sublayers else{
+            return
+        }
+        for gradient in sublayers where gradient is CAGradientLayer{
+            gradient.frame = CGRect(origin: gradient.frame.origin, size: tag.layer.frame.size)
+        }
     }
 }
 

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -28,18 +28,6 @@ class ViewController: UIViewController, TagListViewDelegate {
             self?.tagListView.removeTagView(tagView)
         }
 
-        let tag = tagListView.addTag("Example")
-        tag.paddingX = 12
-        tag.paddingY = 14
-        tag.enableRemoveButton = true
-        let gradient = CAGradientLayer()
-        gradient.colors = [#colorLiteral(red: 0.9803921569, green: 0.9803921569, blue: 0, alpha: 1).cgColor, #colorLiteral(red: 0.9803921569, green: 0.8156862745, blue: 0, alpha: 1).cgColor]
-        gradient.startPoint = .zero
-        gradient.endPoint = CGPoint(x: 1, y: 1)
-        gradient.frame = CGRect(origin: CGPoint(x: 5, y: 5), size: tag.layer.frame.size)
-        tag.layer.addSublayer(gradient)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateTagFrame(from:)), name: .TagViewFrameWasUpdatedNotification, object: tag)
-
         let tagView = tagListView.addTag("gray")
         tagView.tagBackgroundColor = UIColor.gray
         tagView.onTap = { tagView in
@@ -81,15 +69,6 @@ class ViewController: UIViewController, TagListViewDelegate {
     func tagRemoveButtonPressed(_ title: String, tagView: TagView, sender: TagListView) {
         print("Tag Remove pressed: \(title), \(sender)")
         sender.removeTagView(tagView)
-    }
-
-    @objc func updateTagFrame(from notification: Notification) -> Void{
-        guard let tag = notification.object as? TagView, let sublayers = tag.layer.sublayers else{
-            return
-        }
-        for gradient in sublayers where gradient is CAGradientLayer{
-            gradient.frame = CGRect(origin: gradient.frame.origin, size: tag.layer.frame.size)
-        }
     }
 }
 


### PR DESCRIPTION
This provides a fix for Issue #140. This will resize all sublayers of a tag view's `layer` to match its `frame` when its `frame` is updated, if the sublayer was initially equal to the `layer`'s `frame`. If it's not, it provides an optional configuration point (in the form of a `Notification`) for the user to edit its sublayers manually when when the tag view's `frame` is updated