### PR TITLE
Custom tag views

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -274,18 +274,9 @@ open class TagListView: UIView {
     }
     
     // MARK: - Manage tags
-    
-    override open var intrinsicContentSize: CGSize {
-        var height = CGFloat(rows) * (tagViewHeight + marginY)
-        if rows > 0 {
-            height -= marginY
-        }
-        return CGSize(width: frame.width, height: height)
-    }
-    
-    private func createNewTagView(_ title: String) -> TagView {
-        let tagView = TagView(title: title)
-        
+
+    @discardableResult
+    open func stylize(tag tagView: TagView) -> TagView{
         tagView.textColor = textColor
         tagView.selectedTextColor = selectedTextColor
         tagView.tagBackgroundColor = tagBackgroundColor
@@ -304,27 +295,35 @@ open class TagListView: UIView {
         tagView.removeIconLineColor = removeIconLineColor
         tagView.addTarget(self, action: #selector(tagPressed(_:)), for: .touchUpInside)
         tagView.removeButton.addTarget(self, action: #selector(removeButtonPressed(_:)), for: .touchUpInside)
-        
+
         // On long press, deselect all tags except this one
         tagView.onLongPress = { [unowned self] this in
             for tag in self.tagViews {
                 tag.isSelected = (tag == this)
             }
         }
-        
+
         return tagView
+    }
+    
+    override open var intrinsicContentSize: CGSize {
+        var height = CGFloat(rows) * (tagViewHeight + marginY)
+        if rows > 0 {
+            height -= marginY
+        }
+        return CGSize(width: frame.width, height: height)
     }
 
     @discardableResult
     open func addTag(_ title: String) -> TagView {
-        return addTagView(createNewTagView(title))
+        return addTagView(TagView(title: title))
     }
     
     @discardableResult
     open func addTags(_ titles: [String]) -> [TagView] {
         var tagViews: [TagView] = []
         for title in titles {
-            tagViews.append(createNewTagView(title))
+            tagViews.append(TagView(title: title))
         }
         return addTagViews(tagViews)
     }
@@ -332,8 +331,7 @@ open class TagListView: UIView {
     @discardableResult
     open func addTagViews(_ tagViews: [TagView]) -> [TagView] {
         for tagView in tagViews {
-            self.tagViews.append(tagView)
-            tagBackgroundViews.append(UIView(frame: tagView.bounds))
+            addTagView(tagView)
         }
         rearrangeViews()
         return tagViews
@@ -341,12 +339,12 @@ open class TagListView: UIView {
 
     @discardableResult
     open func insertTag(_ title: String, at index: Int) -> TagView {
-        return insertTagView(createNewTagView(title), at: index)
+        return insertTagView(TagView(title: title), at: index)
     }
     
     @discardableResult
     open func addTagView(_ tagView: TagView) -> TagView {
-        tagViews.append(tagView)
+        tagViews.append(stylize(tag: tagView))
         tagBackgroundViews.append(UIView(frame: tagView.bounds))
         rearrangeViews()
         
@@ -355,7 +353,7 @@ open class TagListView: UIView {
 
     @discardableResult
     open func insertTagView(_ tagView: TagView, at index: Int) -> TagView {
-        tagViews.insert(tagView, at: index)
+        tagViews.insert(stylize(tag: tagView), at: index)
         tagBackgroundViews.insert(UIView(frame: tagView.bounds), at: index)
         rearrangeViews()
         

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -327,7 +327,13 @@ open class TagListView: UIView {
         }
         return addTagViews(tagViews)
     }
-    
+
+    /**
+     Adds the specified `TagView`s to the `TagListView`
+     - Parameter tagViews: The `TagView`s to be added
+     - Returns: The `TagView`s that were added
+     - Important: This method applies all default styling of the `TagListView`, so if you're gonna do any special styling it individual tags, do it after calling this method
+     */
     @discardableResult
     open func addTagViews(_ tagViews: [TagView]) -> [TagView] {
         for tagView in tagViews {
@@ -341,7 +347,13 @@ open class TagListView: UIView {
     open func insertTag(_ title: String, at index: Int) -> TagView {
         return insertTagView(TagView(title: title), at: index)
     }
-    
+
+    /**
+     Adds the specified `TagView` to the `TagListView`
+     - Parameter tagView: The `TagView` to be added
+     - Returns: The `TagView` that was added
+     - Important: This method applies all default styling of the `TagListView`, so if you're gonna do any special styling, do it after calling this method
+     */
     @discardableResult
     open func addTagView(_ tagView: TagView) -> TagView {
         tagViews.append(stylize(tag: tagView))
@@ -351,6 +363,13 @@ open class TagListView: UIView {
         return tagView
     }
 
+    /**
+     Adds the specified `TagView` to the `TagListView` at the specified index
+     - Parameter tagView: The `TagView` to be added
+     - Parameter index: The index at which to insert the `tagView`
+     - Returns: The `TagView` that was added
+     - Important: This method applies all default styling of the `TagListView`, so if you're gonna do any special styling, do it after calling this method
+     */
     @discardableResult
     open func insertTagView(_ tagView: TagView, at index: Int) -> TagView {
         tagViews.insert(stylize(tag: tagView), at: index)

--- a/TagListView/TagView.swift
+++ b/TagListView/TagView.swift
@@ -157,7 +157,7 @@ open class TagView: UIButton {
     
     public init(title: String) {
         super.init(frame: CGRect.zero)
-        setTitle(title, for: UIControlState())
+        setTitle(title, for: .normal)
         
         setupView()
     }

--- a/TagListViewDemo/Base.lproj/Main.storyboard
+++ b/TagListViewDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13189.4" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13165.3"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -15,12 +19,12 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4S7-JK-aUE" customClass="TagListView" customModule="TagListViewDemo" customModuleProvider="target">
-                                <rect key="frame" x="20" y="122" width="297" height="24"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <rect key="frame" x="16" y="122" width="297" height="24"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="277" id="1oP-qJ-5CN"/>
                                     <constraint firstAttribute="height" priority="250" constant="82" id="Eqd-9H-22r"/>
@@ -28,7 +32,7 @@
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagBackgroundColor">
-                                        <color key="value" red="0.34403669720000002" green="0.55810397550000002" blue="0.8980392157" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.34403669720000002" green="0.55810397550000002" blue="0.8980392157" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                         <real key="value" value="12"/>
@@ -53,19 +57,19 @@
                                         <real key="value" value="2"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="removeIconLineColor">
-                                        <color key="value" white="1" alpha="0.60282023993808054" colorSpace="calibratedWhite"/>
+                                        <color key="value" red="1" green="1" blue="1" alpha="0.60282023993808054" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagBorderColor">
-                                        <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                         <real key="value" value="2"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="selectedBorderColor">
-                                        <color key="value" red="0.99215686270000003" green="0.73563590570000004" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.99215686270000003" green="0.73563590570000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagSelectedBackgroundColor">
-                                        <color key="value" red="0.98823529409999999" green="0.23921568630000001" blue="0.22352941179999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="value" red="0.97199046611785889" green="0.13802945613861084" blue="0.17296624183654785" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <variation key="default">
@@ -75,8 +79,8 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n5B-Sc-Dfo" customClass="TagListView" customModule="TagListViewDemo" customModuleProvider="target">
-                                <rect key="frame" x="20" y="158" width="277" height="22"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <rect key="frame" x="16" y="158" width="277" height="22"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" priority="250" constant="82" id="935-sK-xao"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="277" id="9PT-A0-Th9"/>
@@ -85,7 +89,7 @@
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagBackgroundColor">
-                                        <color key="value" red="0.97254901960784312" green="0.46666666666666667" blue="0.074509803921568626" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.97254901960784312" green="0.46666666666666667" blue="0.074509803921568626" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="paddingY">
                                         <real key="value" value="5"/>
@@ -103,17 +107,17 @@
                                         <real key="value" value="5"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                        <color key="value" red="0.98823529409999999" green="0.23921568630000001" blue="0.22352941179999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="value" red="0.97199046611785889" green="0.13802945613861084" blue="0.17296624183654785" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
                                         <real key="value" value="1"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagSelectedBackgroundColor">
-                                        <color key="value" red="0.97254901960784312" green="0.60703363914373087" blue="0.074509803921568626" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.97254901960784312" green="0.60703363914373087" blue="0.074509803921568626" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="enableRemoveButton" value="NO"/>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagHighlightedBackgroundColor">
-                                        <color key="value" red="0.98823529409999999" green="0.23921568630000001" blue="0.22352941179999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="value" red="0.97199046611785889" green="0.13802945613861084" blue="0.17296624183654785" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <variation key="default">
@@ -124,8 +128,8 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2SR-iU-xRm" customClass="TagListView" customModule="TagListViewDemo" customModuleProvider="target">
-                                <rect key="frame" x="20" y="195" width="277" height="22"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="16" y="195" width="277" height="22"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" priority="250" constant="82" id="0nr-i2-gTA"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="277" id="3mJ-aW-u2O"/>
@@ -136,7 +140,7 @@
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagBackgroundColor">
-                                        <color key="value" red="0.20000000000000001" green="0.8666666666666667" blue="0.015686274509803921" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.20000000000000001" green="0.8666666666666667" blue="0.015686274509803921" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="paddingY">
                                         <real key="value" value="5"/>
@@ -151,7 +155,7 @@
                                         <real key="value" value="8"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="tagSelectedBackgroundColor">
-                                        <color key="value" red="0.20000000000000001" green="0.86666666670000003" blue="0.015686274510000001" alpha="0.70000000000000007" colorSpace="calibratedRGB"/>
+                                        <color key="value" red="0.20000000000000001" green="0.86666666670000003" blue="0.015686274510000001" alpha="0.70000000000000007" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <variation key="default">
@@ -163,10 +167,67 @@
                                     </mask>
                                 </variation>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q2Z-C8-NIk" customClass="TagListView" customModule="TagListViewDemo" customModuleProvider="target">
+                                <rect key="frame" x="16" y="225" width="277" height="32"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="82" id="B4z-Cq-IJm"/>
+                                    <constraint firstAttribute="width" constant="277" id="J74-v2-CsP"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="277" id="PeU-30-hBp"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="277" id="Xyh-lb-Md8"/>
+                                    <constraint firstAttribute="height" priority="250" constant="82" id="hJv-FT-IOf"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="w4K-Uw-BzT"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="tagBackgroundColor">
+                                        <color key="value" red="0.035294117649999998" green="0.035294117649999998" blue="0.68627450980000004" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="paddingY">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="paddingX">
+                                        <real key="value" value="12"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="marginX">
+                                        <real key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="marginY">
+                                        <real key="value" value="8"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="tagSelectedBackgroundColor">
+                                        <color key="value" red="0.96470588239999999" green="0.4823529412" blue="0.031372549020000001" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                        <color key="value" red="0.98039215690000003" green="0.89411764709999997" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="selectedTextColor">
+                                        <color key="value" red="0.98039215690000003" green="0.89411764709999997" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="removeButtonIconSize">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="removeIconLineWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="B4z-Cq-IJm"/>
+                                        <exclude reference="PeU-30-hBp"/>
+                                        <exclude reference="Xyh-lb-Md8"/>
+                                        <exclude reference="w4K-Uw-BzT"/>
+                                    </mask>
+                                </variation>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="2SR-iU-xRm" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="1ze-6J-vf8"/>
+                            <constraint firstItem="Q2Z-C8-NIk" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="5UK-hG-y58"/>
+                            <constraint firstItem="Q2Z-C8-NIk" firstAttribute="top" secondItem="2SR-iU-xRm" secondAttribute="bottom" constant="8" id="Bdo-rt-EBl"/>
                             <constraint firstItem="4S7-JK-aUE" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="M7a-Ac-6Qz"/>
                             <constraint firstItem="n5B-Sc-Dfo" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="URs-N9-4Pt"/>
                             <constraint firstItem="n5B-Sc-Dfo" firstAttribute="top" secondItem="4S7-JK-aUE" secondAttribute="bottom" constant="12" id="Xgd-WB-f07"/>
@@ -178,6 +239,7 @@
                         <outlet property="biggerTagListView" destination="n5B-Sc-Dfo" id="twE-Sg-GwG"/>
                         <outlet property="biggestTagListView" destination="2SR-iU-xRm" id="ZFD-vV-8WH"/>
                         <outlet property="tagListView" destination="4S7-JK-aUE" id="8yD-JT-l4t"/>
+                        <outlet property="testView" destination="Q2Z-C8-NIk" id="yMa-fD-fQO"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/TagListViewDemo/Base.lproj/Main.storyboard
+++ b/TagListViewDemo/Base.lproj/Main.storyboard
@@ -167,67 +167,10 @@
                                     </mask>
                                 </variation>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q2Z-C8-NIk" customClass="TagListView" customModule="TagListViewDemo" customModuleProvider="target">
-                                <rect key="frame" x="16" y="225" width="277" height="32"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="82" id="B4z-Cq-IJm"/>
-                                    <constraint firstAttribute="width" constant="277" id="J74-v2-CsP"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="277" id="PeU-30-hBp"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="277" id="Xyh-lb-Md8"/>
-                                    <constraint firstAttribute="height" priority="250" constant="82" id="hJv-FT-IOf"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="w4K-Uw-BzT"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="tagBackgroundColor">
-                                        <color key="value" red="0.035294117649999998" green="0.035294117649999998" blue="0.68627450980000004" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="paddingY">
-                                        <real key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="paddingX">
-                                        <real key="value" value="12"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="marginX">
-                                        <real key="value" value="7"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="marginY">
-                                        <real key="value" value="8"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="tagSelectedBackgroundColor">
-                                        <color key="value" red="0.96470588239999999" green="0.4823529412" blue="0.031372549020000001" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
-                                        <color key="value" red="0.98039215690000003" green="0.89411764709999997" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="selectedTextColor">
-                                        <color key="value" red="0.98039215690000003" green="0.89411764709999997" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="5"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="removeButtonIconSize">
-                                        <real key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="removeIconLineWidth">
-                                        <real key="value" value="1"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="B4z-Cq-IJm"/>
-                                        <exclude reference="PeU-30-hBp"/>
-                                        <exclude reference="Xyh-lb-Md8"/>
-                                        <exclude reference="w4K-Uw-BzT"/>
-                                    </mask>
-                                </variation>
-                            </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="2SR-iU-xRm" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="1ze-6J-vf8"/>
-                            <constraint firstItem="Q2Z-C8-NIk" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="5UK-hG-y58"/>
-                            <constraint firstItem="Q2Z-C8-NIk" firstAttribute="top" secondItem="2SR-iU-xRm" secondAttribute="bottom" constant="8" id="Bdo-rt-EBl"/>
                             <constraint firstItem="4S7-JK-aUE" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="M7a-Ac-6Qz"/>
                             <constraint firstItem="n5B-Sc-Dfo" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="URs-N9-4Pt"/>
                             <constraint firstItem="n5B-Sc-Dfo" firstAttribute="top" secondItem="4S7-JK-aUE" secondAttribute="bottom" constant="12" id="Xgd-WB-f07"/>
@@ -239,7 +182,6 @@
                         <outlet property="biggerTagListView" destination="n5B-Sc-Dfo" id="twE-Sg-GwG"/>
                         <outlet property="biggestTagListView" destination="2SR-iU-xRm" id="ZFD-vV-8WH"/>
                         <outlet property="tagListView" destination="4S7-JK-aUE" id="8yD-JT-l4t"/>
-                        <outlet property="testView" destination="Q2Z-C8-NIk" id="yMa-fD-fQO"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -13,7 +13,6 @@ class ViewController: UIViewController, TagListViewDelegate {
     @IBOutlet weak var tagListView: TagListView!
     @IBOutlet weak var biggerTagListView: TagListView!
     @IBOutlet weak var biggestTagListView: TagListView!
-    @IBOutlet weak var testView: TagListView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,12 +52,6 @@ class ViewController: UIViewController, TagListViewDelegate {
         // it is also possible to add all tags in one go
         biggestTagListView.addTags(["all", "your", "tag", "are", "belong", "to", "us"])
         biggestTagListView.alignment = .right
-
-        let tag = MHCustomTag(title: "This is a test")
-        tag.setTitle(tag.example, for: .normal)
-        testView.addTagView(tag)
-        tag.enableRemoveButton = true
-        tag.removeIconLineColor = #colorLiteral(red: 0.9794525504, green: 0.5596447587, blue: 0, alpha: 1)
     }
     
     override func didReceiveMemoryWarning() {
@@ -76,8 +69,4 @@ class ViewController: UIViewController, TagListViewDelegate {
         print("Tag Remove pressed: \(title), \(sender)")
         sender.removeTagView(tagView)
     }
-}
-
-class MHCustomTag: TagView{
-    let example = "This is an example"
 }

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -13,7 +13,8 @@ class ViewController: UIViewController, TagListViewDelegate {
     @IBOutlet weak var tagListView: TagListView!
     @IBOutlet weak var biggerTagListView: TagListView!
     @IBOutlet weak var biggestTagListView: TagListView!
-    
+    @IBOutlet weak var testView: TagListView!
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -52,7 +53,12 @@ class ViewController: UIViewController, TagListViewDelegate {
         // it is also possible to add all tags in one go
         biggestTagListView.addTags(["all", "your", "tag", "are", "belong", "to", "us"])
         biggestTagListView.alignment = .right
-        
+
+        let tag = MHCustomTag(title: "This is a test")
+        tag.setTitle(tag.example, for: .normal)
+        testView.addTagView(tag)
+        tag.enableRemoveButton = true
+        tag.removeIconLineColor = #colorLiteral(red: 0.9794525504, green: 0.5596447587, blue: 0, alpha: 1)
     }
     
     override func didReceiveMemoryWarning() {
@@ -72,3 +78,6 @@ class ViewController: UIViewController, TagListViewDelegate {
     }
 }
 
+class MHCustomTag: TagView{
+    let example = "This is an example"
+}


### PR DESCRIPTION
This provides a fix for Issue #142. This moves the applying of default stylings from a factory method in `TagListView` that's called in `addTag(_:)` to a method that *just* handles styling and is called in `addTagView(_:)` and `insertTagView(_:at:)`. I also changed the implementation of `addTagViews(_:)` to call out to `addTagView(_:)` for each individual tag. Ultimately, this allows for the easy addition of custom subclasses to `TagView`. I added documentation comments for each of the relevant methods to make it clear that they unconditionally apply the styling of the `TagListView` that the `TagView`/subclass is being added to, so any individual tag stylization should take place after calling `addTagView(_:)`, `addTagViews(_:)`, or `insertTagView(_:at:)`