### PR TITLE
Constraint TagView width to TagListView width, new properties for tags line break mode

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -31,6 +31,14 @@ open class TagListView: UIView {
             }
         }
     }
+
+    @IBInspectable open dynamic var tagLineBreakMode: NSLineBreakMode = .byTruncatingMiddle {
+        didSet {
+            for tagView in tagViews {
+                tagView.titleLineBreakMode = tagLineBreakMode
+            }
+        }
+    }
     
     @IBInspectable open dynamic var tagBackgroundColor: UIColor = UIColor.gray {
         didSet {
@@ -241,6 +249,8 @@ open class TagListView: UIView {
                 
                 rowViews.append(currentRowView)
                 addSubview(currentRowView)
+
+                tagView.frame.size.width = min(tagView.frame.size.width, frame.width)
             }
             
             let tagBackgroundView = tagBackgroundViews[index]
@@ -291,6 +301,7 @@ open class TagListView: UIView {
         tagView.tagBackgroundColor = tagBackgroundColor
         tagView.highlightedBackgroundColor = tagHighlightedBackgroundColor
         tagView.selectedBackgroundColor = tagSelectedBackgroundColor
+        tagView.titleLineBreakMode = tagLineBreakMode
         tagView.cornerRadius = cornerRadius
         tagView.borderWidth = borderWidth
         tagView.borderColor = borderColor

--- a/TagListView/TagView.swift
+++ b/TagListView/TagView.swift
@@ -39,6 +39,11 @@ open class TagView: UIButton {
             reloadStyles()
         }
     }
+    @IBInspectable open var titleLineBreakMode: NSLineBreakMode = .byTruncatingMiddle {
+        didSet {
+            titleLabel?.lineBreakMode = titleLineBreakMode
+        }
+    }
     @IBInspectable open var paddingY: CGFloat = 2 {
         didSet {
             titleEdgeInsets.top = paddingY
@@ -163,6 +168,8 @@ open class TagView: UIButton {
     }
     
     private func setupView() {
+        titleLabel?.lineBreakMode = titleLineBreakMode
+
         frame.size = intrinsicContentSize
         addSubview(removeButton)
         removeButton.tagView = self


### PR DESCRIPTION
Similar to https://github.com/ElaWorkshop/TagListView/pull/129, however we don't set maxWidth explicitly, rather constrain the tags width to the width of TagListView.

Right now if one tag is too long to fit TagListView, it just goes to overflowing container, like this:
<img width="371" alt="screenshot 2017-09-06 10 48 02" src="https://user-images.githubusercontent.com/346042/30100250-e2ac421c-92f0-11e7-8614-e63b03c8b7ef.png">

With this PR tags which don't fit one line get truncated and you can control lineBreakMode using vars:
<img width="375" alt="screenshot 2017-09-06 10 46 02" src="https://user-images.githubusercontent.com/346042/30100204-ba5c2840-92f0-11e7-8f70-d2b574266a8d.png">
