### PR TITLE
Correctly calculate `intrinsicContentSize` before first layout run

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -187,6 +187,15 @@ open class TagListView: UIView {
             }
         }
     }
+
+    /// The desired (maximum) width of the whole view. This needs to be set in cases where
+    /// the `intrinsicContentSize` should to be calculated before or without the view being
+    /// previously layouted. For example when using `systemLayoutSizeFitting:`.
+    @IBInspectable open dynamic var preferredLayoutWidth: CGFloat = -1 {
+        didSet {
+            rearrangeViews()
+        }
+    }
     
     @objc open dynamic var textFont: UIFont = .systemFont(ofSize: 12) {
         didSet {
@@ -230,6 +239,8 @@ open class TagListView: UIView {
             $0.removeFromSuperview()
         }
         rowViews.removeAll(keepingCapacity: true)
+
+        let layoutWidth = preferredLayoutWidth >= 0 ? preferredLayoutWidth : frame.width
         
         var currentRow = 0
         var currentRowView: UIView!
@@ -239,7 +250,7 @@ open class TagListView: UIView {
             tagView.frame.size = tagView.intrinsicContentSize
             tagViewHeight = tagView.frame.height
             
-            if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width > frame.width {
+            if currentRowTagCount == 0 || currentRowWidth + tagView.frame.width > layoutWidth {
                 currentRow += 1
                 currentRowWidth = 0
                 currentRowTagCount = 0
@@ -249,7 +260,7 @@ open class TagListView: UIView {
                 rowViews.append(currentRowView)
                 addSubview(currentRowView)
 
-                tagView.frame.size.width = min(tagView.frame.size.width, frame.width)
+                tagView.frame.size.width = min(tagView.frame.size.width, layoutWidth)
             }
             
             let tagBackgroundView = tagBackgroundViews[index]
@@ -270,9 +281,9 @@ open class TagListView: UIView {
             case .left:
                 currentRowView.frame.origin.x = 0
             case .center:
-                currentRowView.frame.origin.x = (frame.width - (currentRowWidth - marginX)) / 2
+                currentRowView.frame.origin.x = (layoutWidth - (currentRowWidth - marginX)) / 2
             case .right:
-                currentRowView.frame.origin.x = frame.width - (currentRowWidth - marginX)
+                currentRowView.frame.origin.x = layoutWidth - (currentRowWidth - marginX)
             }
             currentRowView.frame.size.width = currentRowWidth
             currentRowView.frame.size.height = max(tagViewHeight, currentRowView.frame.height)
@@ -289,7 +300,11 @@ open class TagListView: UIView {
         if rows > 0 {
             height -= marginY
         }
-        return CGSize(width: frame.width, height: height)
+
+        // Take the width of the widest rowView to determine the intrinsic content width
+        let width = rowViews.map({ $0.frame.width }).sorted().last ?? 0.0
+
+        return CGSize(width: width, height: height)
     }
     
     private func createNewTagView(_ title: String) -> TagView {


### PR DESCRIPTION
This pull requests adds the ability to calculate the `intrinsicContentSize` of `TagListView` without requiring a full layout-run. This is for example the case if some one wants to pre-calculate the sizes of collection-view cells (with `systemLayoutSizeFitting (...)`) that have a `TagListView` embedded.

In my case, the `intrinsicContentSize` was always wrong (height: number of tag x tag-height), because the tag-list inside my static prototyping cell (which is used for size-pre-calculation) was not layouted yet. And since layouting the whole cell is more expensive then using `systemLayoutSizeFitting()` while gathering the correct cell sizes is critical for scrolling performance of the whole collection-view, I had to find a way to calculate the `intrinsicContentSize` without that dependency from the view's frame.

BTW: Even Apples documentation for `intrinsicContentSize` says: 
> This intrinsic size must be independent of the content frame

My solution is inspired from `UILabel`'s `preferredMaxLayoutWidth`, since multiline labels have the same requirement to calculate it's height depending of their width, which they don't know prior layouting.

So in `rearrangeViews()` the `TagListView` uses the newly introduced `preferredLayoutWidth` property (if set to a proper value) for calculating the distribution of all tags (instead of `frame.width`).
The getter of `intrinsicContentSize` then looks for the widest row-view to determine the tag-list-view's intrinsic width.

When using autolayout, the tag-list-view will then be sized based on it's `intrinsicContentSize`.
