### PR TITLE
Fix iOS 13 issue #225

### DIFF
--- a/TagListView/TagView.swift
+++ b/TagListView/TagView.swift
@@ -185,7 +185,7 @@ open class TagView: UIButton {
     // MARK: - layout
 
     override open var intrinsicContentSize: CGSize {
-        var size = titleLabel?.text?.size(withAttributes: [NSAttributedString.Key.font: textFont]) ?? CGSize.zero
+        var size = super.intrinsicContentSize
         size.height = textFont.pointSize + paddingY * 2
         size.width += paddingX * 2
         if size.width < size.height {


### PR DESCRIPTION
This fixes the elipsized text in the tags that appears in iOS 13.

Applied the suggested fix of the issue comment:
https://github.com/ElaWorkshop/TagListView/issues/225#issuecomment-506665179

Have tested the changes in our own project with iOS 13 and iOS 12. Still works with iOS 12 and fixes the issue in iOS 13