### PR TITLE
fix addTagViews: avoid redundant rearrangeViews invoke

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -381,9 +381,11 @@ open class TagListView: UIView {
     }
     
     @discardableResult
-    open func addTagViews(_ tagViews: [TagView]) -> [TagView] {
-        tagViews.forEach {
-            addTagView($0)
+    open func addTagViews(_ tagViewList: [TagView]) -> [TagView] {
+        defer { rearrangeViews() }
+        tagViewList.forEach {
+            tagViews.append($0)
+            tagBackgroundViews.append(UIView(frame: $0.bounds))
         }
         return tagViews
     }


### PR DESCRIPTION
## addTagViews has Performance issues. 
the `rearrangeViews` runs so many times when multiple tags are added.
 in my situation, i have 170+ tags to display, and it cost about 6 seconds to display.
after modify `addTagViews`, the time cost reduce to 0.13ms