### PR TITLE
Add minWidth property

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can add tag to the tag list view, or set custom font and alignment through c
 ```swift
 tagListView.textFont = UIFont.systemFont(ofSize: 24)
 tagListView.alignment = .center // possible values are [.leading, .trailing, .left, .center, .right]
+tagListView.minWidth = 57
 
 tagListView.addTag("TagListView")
 tagListView.addTags(["Add", "two", "tags"])

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -121,6 +121,12 @@ open class TagListView: UIView {
             rearrangeViews()
         }
     }
+
+    @IBInspectable open dynamic var minWidth: CGFloat = 0 {
+        didSet {
+            rearrangeViews()
+        }
+    }
     
     @objc public enum Alignment: Int {
         case left
@@ -288,6 +294,7 @@ open class TagListView: UIView {
                 x: currentRowWidth,
                 y: 0)
             tagBackgroundView.frame.size = tagView.bounds.size
+            tagView.frame.size.width = max(minWidth, tagView.frame.size.width)
             tagBackgroundView.layer.shadowColor = shadowColor.cgColor
             tagBackgroundView.layer.shadowPath = UIBezierPath(roundedRect: tagBackgroundView.bounds, cornerRadius: cornerRadius).cgPath
             tagBackgroundView.layer.shadowOffset = shadowOffset

--- a/TagListViewDemo/ViewController.swift
+++ b/TagListViewDemo/ViewController.swift
@@ -51,6 +51,7 @@ class ViewController: UIViewController, TagListViewDelegate {
         biggestTagListView.textFont = .systemFont(ofSize: 24)
         // it is also possible to add all tags in one go
         biggestTagListView.addTags(["all", "your", "tag", "are", "belong", "to", "us"])
+        biggestTagListView.minWidth = 57
         biggestTagListView.alignment = .right
         
     }


### PR DESCRIPTION
I needed, so added.

```swift
        biggestTagListView.addTags(["all", "your", "tag", "are", "belong", "to", "us"])
        biggestTagListView.minWidth = 57 // NEW
        biggestTagListView.alignment = .right
```

| minWidth = 0 (default) | minWidth = 57 |
|---|---|
| <img width="261" alt="スクリーンショット 2021-02-23 20 45 16" src="https://user-images.githubusercontent.com/6007952/108839229-25c6a480-7618-11eb-9b9c-055ee8cf6d1e.png"> | <img width="244" alt="スクリーンショット 2021-02-23 20 44 07" src="https://user-images.githubusercontent.com/6007952/108839224-23fce100-7618-11eb-8687-74b345e740fe.png"> |

There should be no effect for existing code on user side.